### PR TITLE
Downgrade server error retry log from WARNING to INFO

### DIFF
--- a/src/discord_utils.py
+++ b/src/discord_utils.py
@@ -41,7 +41,7 @@ async def discord_api_call_with_backoff(coro_func, *args, **kwargs):
         except discord.HTTPException as e:
             last_exception = e
             if e.status >= 500:
-                logger.warning(
+                logger.info(
                     f"Discord server error ({e.status}). Attempt {attempt + 1}/{DiscordRetryConfig.MAX_ATTEMPTS}. "
                     f"Waiting {backoff:.1f}s before retry..."
                 )


### PR DESCRIPTION
## Summary
- Transient 503 retry messages were logged at `WARNING`, which Railway picked up as `[ERROR]` alerts
- Downgraded to `INFO` so only genuine failures (all retries exhausted) trigger alerts

## Test plan
- [ ] Verify Railway alerts stop firing for transient 503 retries
- [ ] Confirm `ERROR`-level log still fires when all retry attempts are exhausted