### PR TITLE
Remove unused Site() call from event_streams module load

### DIFF
--- a/src/event_streams.py
+++ b/src/event_streams.py
@@ -12,7 +12,6 @@ from typing import Dict, List, Optional, Tuple
 
 import discord
 import requests
-from pywikibot import Site
 from pywikibot import config as pwb_config
 from pywikibot.comms.eventstreams import EventStreams
 
@@ -44,7 +43,6 @@ from src.bot_instance import bot
 # ── MediaWiki EventStreams setup                                             #
 # --------------------------------------------------------------------------- #
 
-site = Site()  # default site; EventStreams ignores this for global streams
 pwb_config.user_agent_description = USER_AGENT
 
 # EventStreams requires `since=` as Unix-ms epoch or ISO-8601 timestamp


### PR DESCRIPTION
## Summary
- `site = Site()` in `src/event_streams.py` was assigned at import time but never referenced anywhere in the module (the inline comment even noted EventStreams ignores it for global streams).
- Pywikibot's `Site` constructor issues a `meta=userinfo` request to the default wiki (`test.wikipedia.org`), so every process start hit the MediaWiki API unnecessarily.
- Observed contributing to `429 Too Many Requests` warnings on `test.wikipedia.org` during a Discord-side outage that caused a Railway restart loop today.
- Also drops the now-unused `from pywikibot import Site` import.

## Test plan
- [x] `pytest tests/` passes locally
- [ ] After merge: confirm Railway logs no longer show `wikipedia:test` userinfo / 429 warnings on startup