### PR TITLE
Don't permanently disable receivers on transient webhook failures

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -114,12 +114,24 @@ def load_config() -> dict:
     return raw
 
 
-def save_config(cfg: dict) -> None:
+def save_config(cfg: dict) -> bool:
+    """Atomically persist the config. Returns True on success, False on failure.
+
+    A write failure (read-only / full volume, permissions) is logged at ERROR
+    and swallowed rather than propagated — a persistence problem must not crash
+    the EventStreams worker or a command handler. The in-memory CONFIG remains
+    authoritative until the process restarts.
+    """
     tmp = STATE_FILE.with_suffix(".tmp")
-    with tmp.open("w", encoding=UTF8_ENCODING) as fp:
-        json.dump(cfg, fp, indent=JSON_INDENT, sort_keys=True)
-    tmp.replace(STATE_FILE)
+    try:
+        with tmp.open("w", encoding=UTF8_ENCODING) as fp:
+            json.dump(cfg, fp, indent=JSON_INDENT, sort_keys=True)
+        tmp.replace(STATE_FILE)
+    except Exception as e:
+        logger.error(f"Failed to persist config to {STATE_FILE}: {e}")
+        return False
     logger.debug(f"Config saved to {STATE_FILE}")
+    return True
 
 
 CONFIG: Dict[str, Any] = load_config()

--- a/src/discord_utils.py
+++ b/src/discord_utils.py
@@ -7,7 +7,16 @@ from src.models import DiscordRetryConfig
 from src.bot_instance import bot
 
 class WebhookError(Exception):
-    """Raised when a webhook send fails permanently."""
+    """Raised when a webhook is permanently broken (404 deleted, 403 forbidden,
+    401 unauthorized, malformed URL). The EventStreams worker disables the
+    receiver in response, since retrying cannot succeed."""
+
+
+class TransientWebhookError(Exception):
+    """Raised when a webhook send fails for a recoverable reason (5xx after
+    retries, network blip, unexpected error). The EventStreams worker logs and
+    drops the single event but keeps the receiver active — a temporary Discord
+    hiccup must not permanently silence a receiver."""
 
 async def discord_api_call_with_backoff(coro_func, *args, **kwargs):
     """
@@ -118,15 +127,33 @@ async def send_webhook_with_backoff(
         await discord_api_call_with_backoff(webhook.send, content)
         return True
     except discord.NotFound:
-        # Webhook was deleted
+        # Webhook was deleted — permanent.
         _WEBHOOK_CACHE.pop(webhook_url, None)
         logger.error(f"Webhook not found for '{receiver_key}' (deleted?)")
         raise WebhookError("Webhook not found (404)")
     except discord.Forbidden:
-        # Permission denied
+        # Permission denied — permanent.
         _WEBHOOK_CACHE.pop(webhook_url, None)
         logger.error(f"Webhook forbidden for '{receiver_key}'")
         raise WebhookError("Webhook forbidden (403)")
     except discord.HTTPException as e:
-        logger.error(f"Webhook HTTP error for '{receiver_key}': {e}")
-        raise WebhookError(f"HTTP error: {e}")
+        # 401 = invalid/revoked token: the webhook is permanently broken.
+        # Everything else (5xx that exhausted retries, 429, etc.) is transient —
+        # disabling the receiver for it would silence it over a passing hiccup.
+        if getattr(e, "status", None) == 401:
+            _WEBHOOK_CACHE.pop(webhook_url, None)
+            logger.error(f"Webhook unauthorized (401) for '{receiver_key}'")
+            raise WebhookError("Webhook unauthorized (401)")
+        logger.warning(
+            f"Transient webhook HTTP error for '{receiver_key}' "
+            f"(status {getattr(e, 'status', '?')}); event dropped, receiver kept active: {e}"
+        )
+        raise TransientWebhookError(f"HTTP {getattr(e, 'status', '?')}: {e}")
+    except Exception as e:
+        # Network errors, timeouts, anything unexpected — treat as transient so a
+        # blip cannot permanently disable the receiver.
+        logger.warning(
+            f"Transient webhook error for '{receiver_key}'; "
+            f"event dropped, receiver kept active: {e}"
+        )
+        raise TransientWebhookError(str(e))

--- a/src/event_streams.py
+++ b/src/event_streams.py
@@ -183,6 +183,29 @@ def format_eventstream_timeout_notice(seconds: float) -> str:
         f"stalled; restarting the bot to recover."
     )
 
+
+async def _announce(channel: Optional[discord.TextChannel], text: str) -> None:
+    """Best-effort post of an operator notice to the main channel; no-op when no
+    channel is available. (send_message_with_backoff swallows its own errors.)"""
+    if channel is not None:
+        await send_message_with_backoff(channel, text)
+
+
+async def _deactivate_dead_thread(
+    tid: int, exc: Exception, channel: Optional[discord.TextChannel]
+) -> None:
+    """Handle a custom thread that is permanently unsendable (deleted / access
+    revoked): deactivate it and announce, so the silent stop is noticed. Stays
+    quiet if `tid` isn't a tracked custom thread."""
+    reason = (
+        "thread not found (deleted?)"
+        if isinstance(exc, discord.NotFound)
+        else "access forbidden"
+    )
+    if await set_custom_thread_active(str(tid), False):
+        logger.error(f"Custom thread {tid} permanently unsendable ({reason}); deactivated")
+        await _announce(channel, format_thread_disabled_notice(tid, reason))
+
 async def eventstream_health_monitor(channel: Optional[discord.TextChannel] = None):
     """
     Monitor the health of the EventStream connection.
@@ -219,10 +242,7 @@ async def eventstream_health_monitor(channel: Optional[discord.TextChannel] = No
             )
             # Announce before dying (best-effort; runs in the async loop so the
             # send can complete before SIGTERM tears the loop down).
-            if channel is not None:
-                await send_message_with_backoff(
-                    channel, format_eventstream_timeout_notice(time_since_last_event)
-                )
+            await _announce(channel, format_eventstream_timeout_notice(time_since_last_event))
             # Terminate the process - external process manager should restart it
             os.kill(os.getpid(), signal.SIGTERM)
             await asyncio.sleep(RetryConfig.GRACE_PERIOD_SECS)  # Grace period
@@ -302,21 +322,7 @@ async def stream_worker(channel: discord.TextChannel):
             ch = await discord_api_call_with_backoff(bot.fetch_channel, tid)
         except (discord.NotFound, discord.Forbidden) as e:
             THREAD_CACHE.pop(tid, None)
-            # Permanently unsendable (deleted / access revoked): deactivate the
-            # thread and announce it, so its silent stop is noticed — mirrors the
-            # receiver-disabled behavior. set_custom_thread_active returns False
-            # if the thread isn't a tracked custom thread (then stay quiet).
-            reason = (
-                "thread not found (deleted?)"
-                if isinstance(e, discord.NotFound)
-                else "access forbidden"
-            )
-            if await set_custom_thread_active(str(tid), False):
-                logger.error(f"Custom thread {tid} permanently unsendable ({reason}); deactivated")
-                if channel is not None:
-                    await send_message_with_backoff(
-                        channel, format_thread_disabled_notice(tid, reason)
-                    )
+            await _deactivate_dead_thread(tid, e, channel)
             return None
         except discord.HTTPException as e:
             logger.warning(f"Failed to fetch channel {tid}: {e}")
@@ -555,10 +561,7 @@ async def stream_worker(channel: discord.TextChannel):
                 # it in the main channel so the silent death gets noticed.
                 logger.error(f"Webhook error for receiver '{key}': {e}")
                 await set_receiver_errored(key)
-                if channel is not None:
-                    await send_message_with_backoff(
-                        channel, format_receiver_disabled_notice(key, str(e))
-                    )
+                await _announce(channel, format_receiver_disabled_notice(key, str(e)))
             except TransientWebhookError as e:
                 # Recoverable failure (5xx/network/timeout): drop this one event
                 # but keep the receiver active so a passing hiccup cannot silence

--- a/src/event_streams.py
+++ b/src/event_streams.py
@@ -30,6 +30,7 @@ from src.config import (
     USER_AGENT,
     STALENESS_SECS,
     set_receiver_errored,
+    set_custom_thread_active,
 )
 from src.discord_utils import (
     discord_api_call_with_backoff,
@@ -158,11 +159,38 @@ def format_receiver_disabled_notice(key: str, reason: str) -> str:
         f"webhook is fixed."
     )
 
-async def eventstream_health_monitor():
+
+def format_thread_disabled_notice(thread_id: int, reason: str) -> str:
+    """Build the main-channel notice posted when a custom thread is auto-disabled
+    because it became permanently unsendable (deleted / no access)."""
+    return (
+        f"⚠️ Custom thread <#{thread_id}> (`{thread_id}`) was automatically "
+        f"deactivated: {reason}\nRecreate the thread (or restore access) to "
+        f"resume routing."
+    )
+
+
+def format_startup_notice() -> str:
+    """Build the main-channel notice posted once when the bot (re)starts."""
+    return "✅ **DiscordFezCollector** started and connected to Wikimedia EventStreams."
+
+
+def format_eventstream_timeout_notice(seconds: float) -> str:
+    """Build the main-channel notice posted before the process restarts itself
+    because the Wikimedia stream went silent."""
+    return (
+        f"⚠️ No Wikimedia events received for {int(seconds)}s — the stream looks "
+        f"stalled; restarting the bot to recover."
+    )
+
+async def eventstream_health_monitor(channel: Optional[discord.TextChannel] = None):
     """
     Monitor the health of the EventStream connection.
     If no events are received within EventStreamConfig.TIMEOUT_SECS, assume the
     connection is dead and terminate the process for external restart.
+
+    If a channel is supplied, a notice is posted there before the restart so the
+    outage is visible (this path runs in the async loop, so the send can flush).
     """
     logger.info(
         f"EventStream health monitor started (timeout: {EventStreamConfig.TIMEOUT_SECS}s, "
@@ -189,6 +217,12 @@ async def eventstream_health_monitor():
                 f"EventStream TIMEOUT: No events received for {time_since_last_event:.0f}s "
                 f"(threshold: {EventStreamConfig.TIMEOUT_SECS}s). Terminating process for restart."
             )
+            # Announce before dying (best-effort; runs in the async loop so the
+            # send can complete before SIGTERM tears the loop down).
+            if channel is not None:
+                await send_message_with_backoff(
+                    channel, format_eventstream_timeout_notice(time_since_last_event)
+                )
             # Terminate the process - external process manager should restart it
             os.kill(os.getpid(), signal.SIGTERM)
             await asyncio.sleep(RetryConfig.GRACE_PERIOD_SECS)  # Grace period
@@ -266,8 +300,23 @@ async def stream_worker(channel: discord.TextChannel):
             return th
         try:
             ch = await discord_api_call_with_backoff(bot.fetch_channel, tid)
-        except (discord.NotFound, discord.Forbidden):
+        except (discord.NotFound, discord.Forbidden) as e:
             THREAD_CACHE.pop(tid, None)
+            # Permanently unsendable (deleted / access revoked): deactivate the
+            # thread and announce it, so its silent stop is noticed — mirrors the
+            # receiver-disabled behavior. set_custom_thread_active returns False
+            # if the thread isn't a tracked custom thread (then stay quiet).
+            reason = (
+                "thread not found (deleted?)"
+                if isinstance(e, discord.NotFound)
+                else "access forbidden"
+            )
+            if await set_custom_thread_active(str(tid), False):
+                logger.error(f"Custom thread {tid} permanently unsendable ({reason}); deactivated")
+                if channel is not None:
+                    await send_message_with_backoff(
+                        channel, format_thread_disabled_notice(tid, reason)
+                    )
             return None
         except discord.HTTPException as e:
             logger.warning(f"Failed to fetch channel {tid}: {e}")

--- a/src/event_streams.py
+++ b/src/event_streams.py
@@ -477,8 +477,10 @@ async def stream_worker(channel: discord.TextChannel):
             event_queue.task_done()
             continue
 
-        # Determine routing targets: (messageable, link_style) tuples
-        targets: List[Tuple[discord.abc.Messageable, str]] = []
+        # Determine routing targets: (thread_id, messageable, link_style) tuples.
+        # The thread_id is carried so a failed send can evict the cached thread
+        # object (see the send loop below).
+        targets: List[Tuple[int, discord.abc.Messageable, str]] = []
         receiver_targets: List[Tuple[str, str]] = []  # (key, link_style)
 
         # Custom threads and receivers
@@ -510,7 +512,7 @@ async def stream_worker(channel: discord.TextChannel):
                     if filt.matches(change):
                         th = await get_thread_obj(tid)
                         if th is not None:
-                            targets.append((th, filt.link_style))
+                            targets.append((tid, th, filt.link_style))
                 except Exception as e:  # pragma: no cover
                     logger.warning(f"Custom filter error for {tid}: {e}")
 
@@ -544,8 +546,18 @@ async def stream_worker(channel: discord.TextChannel):
                 len(targets),
                 len(receiver_targets),
             )
-        for tgt, style in targets:
-            await send_message_with_backoff(tgt, _get_msg(style))
+        for tid, tgt, style in targets:
+            sent = await send_message_with_backoff(tgt, _get_msg(style))
+            if sent is None:
+                # Send to a cached thread failed (deleted, access revoked, or a
+                # transient blip). Evict it so the next matching event misses the
+                # cache and re-runs get_thread_obj's classification: a successful
+                # refetch means it was transient (re-cached, no harm); a
+                # NotFound/Forbidden deactivates the thread and announces it.
+                # Without this, a thread that goes permanently unsendable while
+                # cached would drop every event silently — the same silent
+                # failure this change set is meant to eliminate.
+                THREAD_CACHE.pop(tid, None)
 
         # Send to receiver webhooks (uses discord.py native webhook support)
         for key, style in receiver_targets:

--- a/src/event_streams.py
+++ b/src/event_streams.py
@@ -36,6 +36,7 @@ from src.discord_utils import (
     send_message_with_backoff,
     send_webhook_with_backoff,
     WebhookError,
+    TransientWebhookError,
 )
 from src.bot_instance import bot
 
@@ -488,8 +489,14 @@ async def stream_worker(channel: discord.TextChannel):
             try:
                 await send_webhook_with_backoff(webhook_url, _get_msg(style), key)
             except WebhookError as e:
+                # Permanent failure (404/403/401/bad URL): disable the receiver
+                # so it stops trying a webhook that cannot succeed.
                 logger.error(f"Webhook error for receiver '{key}': {e}")
-                # Mark receiver as errored so it stops receiving
                 await set_receiver_errored(key)
+            except TransientWebhookError as e:
+                # Recoverable failure (5xx/network/timeout): drop this one event
+                # but keep the receiver active so a passing hiccup cannot silence
+                # it indefinitely. (Already logged at WARNING in the sender.)
+                logger.debug(f"Transient webhook failure for receiver '{key}': {e}")
 
         event_queue.task_done()

--- a/src/event_streams.py
+++ b/src/event_streams.py
@@ -146,6 +146,18 @@ def format_change(change: dict, *, link_style: str = "title") -> str:
             return f"**{user}** [modified](<{page_url}>) **{title}** ({comment})"
         return f"**{user}** modified **[{title}](<{page_url}>)** ({comment})"
 
+def format_receiver_disabled_notice(key: str, reason: str) -> str:
+    """Build the main-channel notice posted when a receiver is auto-disabled.
+
+    Surfaces the silent failure: which receiver, why, and how to recover — so a
+    permanently-broken webhook is noticed instead of dying quietly.
+    """
+    return (
+        f"⚠️ Receiver **{key}** was automatically disabled after a webhook "
+        f"failure: {reason}\nReactivate with `/receiver activate {key}` once the "
+        f"webhook is fixed."
+    )
+
 async def eventstream_health_monitor():
     """
     Monitor the health of the EventStream connection.
@@ -490,9 +502,14 @@ async def stream_worker(channel: discord.TextChannel):
                 await send_webhook_with_backoff(webhook_url, _get_msg(style), key)
             except WebhookError as e:
                 # Permanent failure (404/403/401/bad URL): disable the receiver
-                # so it stops trying a webhook that cannot succeed.
+                # so it stops trying a webhook that cannot succeed, and announce
+                # it in the main channel so the silent death gets noticed.
                 logger.error(f"Webhook error for receiver '{key}': {e}")
                 await set_receiver_errored(key)
+                if channel is not None:
+                    await send_message_with_backoff(
+                        channel, format_receiver_disabled_notice(key, str(e))
+                    )
             except TransientWebhookError as e:
                 # Recoverable failure (5xx/network/timeout): drop this one event
                 # but keep the receiver active so a passing hiccup cannot silence

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,13 @@ from src.config import DISCORD_TOKEN, DISCORD_CHANNEL_ID, validate_env
 from src.bot_instance import bot
 # Import commands to ensure they are registered
 import src.commands  # noqa: F401 — triggers command registration
-from src.event_streams import stream_worker, eventstream_health_monitor, THREAD_CACHE
+from src.event_streams import (
+    stream_worker,
+    eventstream_health_monitor,
+    THREAD_CACHE,
+    format_startup_notice,
+)
+from src.discord_utils import send_message_with_backoff
 
 # --------------------------------------------------------------------------- #
 # ── Lifecycle events                                                         #
@@ -40,6 +46,7 @@ async def on_thread_delete(thread: discord.Thread):
 
 _stream_task: asyncio.Task = None
 _health_monitor_task: asyncio.Task = None
+_startup_announced: bool = False
 
 @bot.event
 async def on_ready():
@@ -60,19 +67,26 @@ async def on_ready():
         return
         
     logger.info(f"Found target channel: {channel.name} ({channel.id})")
-    
+
+    # Announce startup once per process so every (re)start is visible in the
+    # channel — on_ready can fire more than once, so guard with a flag.
+    global _startup_announced
+    if not _startup_announced:
+        _startup_announced = True
+        await send_message_with_backoff(channel, format_startup_notice())
+
     # Start the background EventStreams task and health monitor once.
     global _stream_task, _health_monitor_task
-    
+
     if _stream_task is None or _stream_task.done():
         logger.info("Starting EventStreams worker task")
         _stream_task = bot.loop.create_task(stream_worker(channel))
     else:
         logger.info("EventStreams worker already running; not starting another one")
-    
+
     if _health_monitor_task is None or _health_monitor_task.done():
         logger.info("Starting EventStream health monitor task")
-        _health_monitor_task = bot.loop.create_task(eventstream_health_monitor())
+        _health_monitor_task = bot.loop.create_task(eventstream_health_monitor(channel))
     else:
         logger.info("EventStream health monitor already running")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -275,3 +275,18 @@ class TestConfigPersistence:
 
         loaded = load_config()
         assert "receivers" in loaded
+
+    def test_save_failure_is_logged_not_raised(self, tmp_path, monkeypatch, caplog):
+        # A write failure (e.g. read-only / full volume) must not propagate and
+        # crash the caller; it should be logged at ERROR and report failure.
+        unwritable = tmp_path / "no_such_dir" / "state.json"  # parent doesn't exist
+        monkeypatch.setattr(config_mod, "STATE_FILE", unwritable)
+
+        with caplog.at_level("ERROR"):
+            result = save_config(CONFIG)  # must not raise
+
+        assert result is False
+        assert any(r.levelname == "ERROR" for r in caplog.records)
+
+    def test_save_success_returns_true(self):
+        assert save_config(CONFIG) is True

--- a/tests/test_operator_notices.py
+++ b/tests/test_operator_notices.py
@@ -1,0 +1,28 @@
+"""Operator-facing failure notices posted to the main channel.
+
+These cover the pure message formatters (the side-effecting sends are wired in
+the worker / on_ready and verified by integration/manual review).
+"""
+from src.event_streams import (
+    format_thread_disabled_notice,
+    format_startup_notice,
+    format_eventstream_timeout_notice,
+)
+
+
+def test_thread_disabled_notice_names_thread_and_reason():
+    note = format_thread_disabled_notice(1397950387641909278, "thread not found (deleted?)")
+    assert "1397950387641909278" in note          # the thread id
+    assert "thread not found (deleted?)" in note    # why
+
+
+def test_startup_notice_is_nonempty_and_signals_start():
+    note = format_startup_notice()
+    assert isinstance(note, str) and note.strip()
+    assert "start" in note.lower()
+
+
+def test_eventstream_timeout_notice_includes_duration_and_restart():
+    note = format_eventstream_timeout_notice(600)
+    assert "600" in note
+    assert "restart" in note.lower()

--- a/tests/test_webhook_resilience.py
+++ b/tests/test_webhook_resilience.py
@@ -1,0 +1,99 @@
+"""Webhook send failure classification: transient vs permanent.
+
+Regression tests for the bug where ANY ``discord.HTTPException`` (including
+transient 5xx / network blips) raised ``WebhookError``, which the EventStreams
+worker treats as a signal to permanently disable the receiver. A transient
+Discord failure must NOT latch a receiver off; only a genuinely broken webhook
+(404 deleted / 403 forbidden / 401 unauthorized) should.
+"""
+import types
+
+import discord
+import pytest
+
+import src.discord_utils as du
+from src.discord_utils import (
+    send_webhook_with_backoff,
+    WebhookError,
+    TransientWebhookError,
+)
+from src.models import DiscordRetryConfig
+
+WEBHOOK_URL = "https://discord.com/api/webhooks/1/token"
+
+
+def _resp(status, reason="err"):
+    """Minimal stand-in for an aiohttp response (discord exceptions read .status/.reason)."""
+    return types.SimpleNamespace(status=status, reason=reason)
+
+
+class _FakeWebhook:
+    """Webhook whose .send always raises the configured exception."""
+
+    def __init__(self, exc):
+        self._exc = exc
+        self.calls = 0
+
+    async def send(self, content):
+        self.calls += 1
+        raise self._exc
+
+
+@pytest.fixture(autouse=True)
+def fast_retries(monkeypatch):
+    """Make the 5xx retry loop instant and short so tests don't sleep."""
+    monkeypatch.setattr(DiscordRetryConfig, "MAX_ATTEMPTS", 2)
+    monkeypatch.setattr(DiscordRetryConfig, "INITIAL_BACKOFF_SECS", 0.0)
+    monkeypatch.setattr(DiscordRetryConfig, "MAX_BACKOFF_SECS", 0.0)
+
+
+def _install(monkeypatch, exc):
+    """Seed the webhook cache so from_url is bypassed; return the fake webhook."""
+    fake = _FakeWebhook(exc)
+    monkeypatch.setitem(du._WEBHOOK_CACHE, WEBHOOK_URL, fake)
+    return fake
+
+
+# ── Permanent failures → WebhookError (caller disables the receiver) ────────
+
+async def test_404_deleted_is_permanent(monkeypatch):
+    _install(monkeypatch, discord.NotFound(_resp(404), "deleted"))
+    with pytest.raises(WebhookError):
+        await send_webhook_with_backoff(WEBHOOK_URL, "hi", "spi")
+
+
+async def test_403_forbidden_is_permanent(monkeypatch):
+    _install(monkeypatch, discord.Forbidden(_resp(403), "forbidden"))
+    with pytest.raises(WebhookError):
+        await send_webhook_with_backoff(WEBHOOK_URL, "hi", "spi")
+
+
+async def test_401_unauthorized_is_permanent(monkeypatch):
+    _install(monkeypatch, discord.HTTPException(_resp(401), "bad token"))
+    with pytest.raises(WebhookError):
+        await send_webhook_with_backoff(WEBHOOK_URL, "hi", "spi")
+
+
+# ── Transient failures → TransientWebhookError (receiver stays active) ───────
+
+async def test_5xx_is_transient_after_retries(monkeypatch):
+    fake = _install(monkeypatch, discord.HTTPException(_resp(503), "unavailable"))
+    with pytest.raises(TransientWebhookError):
+        await send_webhook_with_backoff(WEBHOOK_URL, "hi", "spi")
+    # It retried up to the limit rather than giving up / disabling immediately.
+    assert fake.calls == DiscordRetryConfig.MAX_ATTEMPTS
+
+
+async def test_network_error_is_transient(monkeypatch):
+    _install(monkeypatch, OSError("connection reset by peer"))
+    with pytest.raises(TransientWebhookError):
+        await send_webhook_with_backoff(WEBHOOK_URL, "hi", "spi")
+
+
+# ── The two error classes must be distinct so the caller can tell them apart ─
+
+def test_transient_is_not_a_webhookerror():
+    # event_streams.py disables receivers on `except WebhookError`; a transient
+    # failure must not be caught by that clause.
+    assert not issubclass(TransientWebhookError, WebhookError)
+    assert not issubclass(WebhookError, TransientWebhookError)

--- a/tests/test_webhook_resilience.py
+++ b/tests/test_webhook_resilience.py
@@ -97,3 +97,14 @@ def test_transient_is_not_a_webhookerror():
     # failure must not be caught by that clause.
     assert not issubclass(TransientWebhookError, WebhookError)
     assert not issubclass(WebhookError, TransientWebhookError)
+
+
+# ── Operator notification when a receiver is auto-disabled ───────────────────
+
+def test_disabled_notice_names_receiver_reason_and_recovery():
+    from src.event_streams import format_receiver_disabled_notice
+
+    note = format_receiver_disabled_notice("spi", "Webhook not found (404)")
+    assert "spi" in note                       # which receiver
+    assert "Webhook not found (404)" in note    # why
+    assert "/receiver activate spi" in note     # how to recover


### PR DESCRIPTION
## Problem

All three webhook receivers (`spi`, `clerk`, `spiextra`) were found `errored: True` / `active: False` in production — silently dropped around April with no notification and no auto-recovery.

Root cause: `send_webhook_with_backoff` raised `WebhookError` on **any** `discord.HTTPException`, and the EventStreams worker treats `WebhookError` as a signal to permanently disable the receiver (`set_receiver_errored`). So a **transient** failure (a 5xx that outlived the retry budget, a network blip) permanently latched a receiver off until an owner manually ran `/receiver activate`. All three going dark together points to one shared transient event that failed sends to all of them at once. More broadly, the bot had several **silent failure modes** an operator could not see.

## Changes

**1. Classify webhook failures as permanent vs transient.**

| Failure | Class | Worker reaction |
|---|---|---|
| 404 deleted, 403 forbidden, 401 unauthorized, malformed URL | `WebhookError` (permanent) | disable receiver (unchanged) |
| 5xx after retries, network/timeout, unexpected error | `TransientWebhookError` (**new**) | log + drop the single event, **keep receiver active** |

Rule: disable only when retrying the same URL is provably futile (404/403/401), backed by the cost asymmetry — a wrong "permanent" = silent indefinite data loss (the bug we hit); a wrong "transient" = one dropped event + a log line. When in doubt, transient. (discord.py already handles 429 internally and `discord_api_call_with_backoff` already retries 5xx; this only changes what happens *after* retries are exhausted.)

**2. Operator-visible failure notices in the main channel.**
- **Receiver auto-disabled** → notice naming the receiver, reason, and `/receiver activate <key>` recovery.
- **Custom thread permanently unsendable** (deleted / access revoked) → deactivate it and post a notice (previously stopped silently — same class of bug as the receivers).
- **Restart visibility** → a one-time startup notice on `on_ready`, plus a pre-death notice from the health monitor before it SIGTERMs on stream timeout (that path runs in the async loop, so the send can flush).

**3. `save_config` hardening (log-only, no Discord notice — per request).** Wrap writes in try/except, log at ERROR, return `bool` instead of letting a failed persist propagate and crash the worker.

## Tests

`tests/test_webhook_resilience.py` (failure taxonomy + receiver-disabled notice), `tests/test_operator_notices.py` (thread/startup/timeout notice formatters), and `save_config` failure-handling in `tests/test_config.py`. Full suite: **113 passed** (101 baseline + 12 new). `py_compile` clean.

## Operational note

The three already-errored receivers were recovered out-of-band via `/receiver activate spi|clerk|spiextra`. This PR prevents recurrence and makes future failures visible; it does not by itself re-enable them.

## Possible follow-up (not in this PR)
- A consecutive-transient-failure threshold to eventually disable a webhook that returns 5xx forever (avoids indefinite per-event log spam).
- Announcing the 3 producer-thread SIGTERM paths (blocked queue, reinit failure, max-backoff) — they run off the async loop, so reliably posting before exit needs `run_coroutine_threadsafe`; the startup notice already makes those restarts visible after the fact.
